### PR TITLE
Fix Markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ FFI API with a more idiomatic and fully typed TypeScript API.
 The Deno FFI binding declarations are generated automatically by `libclang-deno`
 build script which uses the library's APIs to implement a basic C header walker,
 complete with comment JSDoc'ifying. Check out
-[https://github.com/aapoalas/libclang-deno/blob/main/build/build.ts](build.ts)
+[build.ts](https://github.com/aapoalas/libclang-deno/blob/main/build/build.ts)
 for the ugly details.
 
 ## Starting up


### PR DESCRIPTION
A markdown link is `[text](URL)`. To avoid future inversion, think of it as a function call. That is my memo technic for this case.

