### PR TITLE
Remove hard reference to 1.0.0-beta.3 in doc.

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -10,7 +10,7 @@ To use `libclang` in your Deno program, import the `mod.ts` file into your
 program:
 
 ```ts
-import * as libclang from "https://deno.land/x/libclang@1.0.0-beta.3/mod.ts";
+import * as libclang from "https://deno.land/x/libclang/mod.ts";
 ```
 
 You must run your program with the `LIBCLANG_PATH` environment variable set to
@@ -24,7 +24,7 @@ The following code will walk through all the cursors in a given header and log
 their kind and spelling:
 
 ```ts
-import * as libclang from "https://deno.land/x/libclang@1.0.0-beta.3/mod.ts";
+import * as libclang from "https://deno.land/x/libclang/mod.ts";
 
 const index = new libclang.CXIndex();
 


### PR DESCRIPTION
Until you switch to un better deploy pipeline, you should avoid hardcode the lib version in doc.